### PR TITLE
Make dep to parametermanager optional

### DIFF
--- a/src/main/js/bundles/dn_urltoolactivator/manifest.json
+++ b/src/main/js/bundles/dn_urltoolactivator/manifest.json
@@ -11,7 +11,7 @@
     "license": {},
     "productName": "devnet-mapapps-url-toolactivator",
     "startLevel": 100,
-    "dependencies": {
+    "optionalDependencies": {
         "parametermanager": "^4.0.0"
     },
     "components": [


### PR DESCRIPTION
map.apps sdi does not support the parametermananger bundle, since they have their own impl. Please make this optional.